### PR TITLE
Fix #9 inserting macro arguments in resolver

### DIFF
--- a/src/jintp.adb
+++ b/src/jintp.adb
@@ -1846,15 +1846,17 @@ package body Jintp is
                Position : Named_Argument_Vectors.Cursor;
             begin
                Macro_Resolver.Parent_Resolver := Resolver'Unchecked_Access;
+               Init (Macro_Resolver.Values);
                for I in 1 .. Macro.Parameters.Length loop
                   if I <= Source.Macro_Arguments.Length
                     and then Source.Macro_Arguments (Positive (I)).Name
                       = Null_Unbounded_String
                   then
                      --  Positional parameter
-                     Macro_Resolver.Values.Insert
-                       (Macro.Parameters (Positive (I)).Name,
-                        Evaluate
+                     Macro_Resolver.Values.Assocs.Value_Assocs.Insert
+                       (Key => (Kind => String_Expression_Value,
+                                S => Macro.Parameters (Positive (I)).Name),
+                        New_Item => Evaluate
                           (Source.Macro_Arguments (Positive (I)).Argument.all,
                            Resolver));
                   else
@@ -1863,18 +1865,18 @@ package body Jintp is
                         Macro.Parameters (Positive (I)).Name);
                      if Position /= Named_Argument_Vectors.No_Element then
                         --  Named parameter
-                        Macro_Resolver.Values.Insert
-                          (Macro.Parameters (Positive (I)).Name,
-                           Evaluate
+                        Macro_Resolver.Values.Assocs.Value_Assocs.Insert
+                          (Key => (Kind => String_Expression_Value,
+                                   S => Macro.Parameters (Positive (I)).Name),
+                           New_Item => Evaluate
                              (Named_Argument_Vectors.Element (Position).Argument.all,
                               Resolver));
                      elsif Macro.Parameters (Positive (I)).Has_Default_Value then
                         --  Default parameter value
-                        Init (Macro_Resolver.Values);
-                        Include (Macro_Resolver.Values.Assocs.Value_Assocs,
-                                 (Kind => String_Expression_Value,
-                                  S => Macro.Parameters (Positive (I)).Name),
-                                 Macro.Parameters (Positive (I)).Default_Value);
+                        Macro_Resolver.Values.Assocs.Value_Assocs.Insert
+                          (Key => (Kind => String_Expression_Value,
+                                   S => Macro.Parameters (Positive (I)).Name),
+                           New_Item => Macro.Parameters (Positive (I)).Default_Value);
                      end if;
                   end if;
                end loop;


### PR DESCRIPTION
I'm using `Insert` here because duplicate keys should not exist.